### PR TITLE
Possible changes for portability and simplification

### DIFF
--- a/api.lisp
+++ b/api.lisp
@@ -168,49 +168,50 @@ value."
 
 (defun call-api (path
                  &key
-                 (method :GET)
-                 (host "http://localhost:8080")
-                 (body nil)
-                 (content-type "application/json")
-                 (user-agent "cl-k8s 0.0.1")
-                 (insecure-tls-no-verify nil)
-                 (ca-file nil)
-                 (client-certificate nil)
-                 (client-key nil))
-    (let ((uri (concatenate 'string host path)))
-        (print body)
-        (multiple-value-bind (stream code)
-            (drakma:http-request
-                uri
-                :want-stream t
-                :method method
-                :content (if body (json:encode-json-to-string body) nil)
-                :content-type content-type
-                :verify (if insecure-tls-no-verify nil :required)
-                :ca-file ca-file
-                :certificate client-certificate
-                :key client-key
-                :user-agent user-agent)
-            (values (json:decode-json stream) code))))
+                   (method :GET)
+                   (host "http://localhost:8080")
+                   (body nil)
+                   (content-type "application/json")
+                   (user-agent "cl-k8s 0.0.1")
+                   (insecure-tls-no-verify nil)
+                   (ca-file nil)
+                   (client-certificate nil)
+                   (client-key nil))
+  (let ((uri (concatenate 'string host path)))
+    (print body)
+    (multiple-value-bind (stream code)
+        (drakma:http-request
+         uri
+         :want-stream t
+         :method method
+         :content (if body (json:encode-json-to-string body) nil)
+         :content-type content-type
+         :verify (if insecure-tls-no-verify nil :required)
+         :ca-file ca-file
+         :certificate client-certificate
+         :key client-key
+         :user-agent user-agent)
+      (values (json:decode-json stream) code))))
 
 (defun call-api-with-config (path
                              config 
                              &key
-                             (method :GET)
-                             (body nil)
-                             (content-type "application/json")
-                             (user-agent "cl-k8s 0.0.1"))
-    (let ((cluster (current-cluster config))
-          (user (current-user config)))
-        (call-api
-            path
-            :method method
-            :body body
-            :content-type content-type
-            :user-agent user-agent
-            :host (server cluster)
-            :ca-file (certificate-authority cluster)
-            :insecure-tls-no-verify nil ; (get-insecure-tls-no-verify config)
-            :client-certificate (client-certificate user)
-            :client-key (client-key user))))
+                               (method :GET)
+                               (body nil)
+                               (content-type "application/json")
+                               (user-agent "cl-k8s 0.0.1"))
+  (let ((cluster (current-cluster config))
+        (user (current-user config)))
+    (call-api
+     path
+     :method method
+     :body body
+     :content-type content-type
+     :user-agent user-agent
+     :host (server cluster)
+     :ca-file (certificate-authority cluster)
+     :insecure-tls-no-verify nil ; (get-insecure-tls-no-verify config)
+     :client-certificate (client-certificate user)
+     :client-key (client-key user))))
+
 

--- a/api.lisp
+++ b/api.lisp
@@ -90,7 +90,7 @@ value."
            key)
          (and ,object (gethash ,key ,object)))
 
-       ;; Writer .
+       ;; Writer
        (defun (setf ,name) (,value ,object)
          ,(format
            nil
@@ -121,6 +121,7 @@ value."
 ;;;; UTILITY FUNCTIONS
 
 (declaim (inline find-by-name))
+
 (defun find-by-name (name sequence)
   (find name sequence :test #'equal :key #'name))
 
@@ -214,5 +215,4 @@ value."
      :insecure-tls-no-verify nil ; (get-insecure-tls-no-verify config)
      :client-certificate (client-certificate user)
      :client-key (client-key user))))
-
 

--- a/api.lisp
+++ b/api.lisp
@@ -1,9 +1,4 @@
-; TODO: make this more generic
-(load "~/quicklisp/setup.lisp")
-
-(ql:quickload :drakma)
-(ql:quickload :cl-json)
-(ql:quickload :cl-yaclyaml)
+(in-package :cl-kubernetes)
 
 (defun read-file (path)
   (with-open-file (stream path)

--- a/api.lisp
+++ b/api.lisp
@@ -56,8 +56,7 @@ Otherwise, try to read the configuration file from the home user
 directory (~/.kube/config).
 
 If this file does not exist, return a default configuration."
-  (let ((source (or (split (inter-directory-separator)
-                           (getenvp "KUBECONFIG"))
+  (let ((source (or (getenv-pathnames "KUBECONFIG")
                     (probe-file (merge-pathnames #P".kube/config"
                                                  (user-homedir-pathname))))))
     (if source

--- a/api.lisp
+++ b/api.lisp
@@ -2,7 +2,7 @@
 
 (defgeneric load-config (source)
   (:documentation
-   "Load a YAML configuration file from a file or a list of files."))
+   "Load a YAML configuration from a file or a list of files."))
 
 ;; https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#merging-kubeconfig-files
 (defun merge-configurations (&optional current new)

--- a/api.lisp
+++ b/api.lisp
@@ -43,7 +43,8 @@ to satisfy REDUCE and easily build empty configurations)."
   (restart-case (call-next-method)
     (ignore ()
       :report "Ignore this configuration file."
-      (return-from load-config (merge-configurations)))))
+      ;; return empty configuration
+      (merge-configurations))))
 
 (defun default-config ()
   "Load the default configuration in this environment.

--- a/api.lisp
+++ b/api.lisp
@@ -66,11 +66,6 @@ If this file does not exist, return a default configuration."
            ("kind" "Config"))
          :test #'equal))))
 
-(defun find-object (list name)
-    (if list
-        (let ((obj (car list)))
-            (if (string= name (gethash "name" obj)) obj (find-object (cdr list) name)))
-        nil))
 (defmacro define-accessors (name &optional (key (string-downcase name)))
   "Define both NAME and (SETF NAME) to access slot KEY in objects.
 
@@ -130,6 +125,9 @@ value."
 
 (defun get-user (config user)
     (find-object-in-config-list config "users" user))
+(declaim (inline find-by-name))
+(defun find-by-name (name sequence)
+  (find name sequence :test #'equal :key #'name))
 
 (defun get-cluster (config cluster)
     (find-object-in-config-list config "clusters" cluster))

--- a/api.lisp
+++ b/api.lisp
@@ -110,12 +110,13 @@ value."
 (define-accessors users)
 (define-accessors clusters)
 
-;; keys that are references, by names, to objects.
-(define-accessors context-name "context")
-(define-accessors user-name "user")
-(define-accessors cluster-name "cluster")
-(define-accessors current-context-name "current-context")
+;; keys that returns either references, by names, to objects, or
+;; directly an object.
 
+(define-accessors context)
+(define-accessors user)
+(define-accessors cluster)
+(define-accessors current-context)
 
 ;;;; UTILITY FUNCTIONS
 
@@ -150,17 +151,17 @@ value."
 
 (defun get-current-context (config)
   (context
-   (get-context config (current-context-name config))))
+   (get-context config (current-context config))))
 
 (defun get-current-user (config)
   (if-let ((context (get-current-context config)))
     (user
-     (get-user config (user-name context)))))
+     (get-user config (user context)))))
 
 (defun current-cluster (config)
   (if-let ((context (get-current-context config)))
     (cluster
-     (get-cluster config (cluster-name context)))))
+     (get-cluster config (cluster context)))))
 
 
 ;;;; API CALLS

--- a/api.lisp
+++ b/api.lisp
@@ -29,7 +29,7 @@ to satisfy REDUCE and easily build empty configurations)."
   "Load and merge a sequence of configuration files."
   ;; merge according to priority rules.
   (reduce #'merge-configurations
-          ;; may error during deserializeing
+          ;; may error when deserializing
           (mapcar #'load-config
                   ;; ignore non-existing files
                   (delete nil (map 'list #'probe-file sequence)))))
@@ -98,25 +98,20 @@ value."
            key)
          (setf (gethash ,key ,object) ,value)))))
 
-;; values
+;; sorted alphabetically
+
+(define-accessors certificate-authority)
+(define-accessors client-certificate)
+(define-accessors client-key)
+(define-accessors cluster)
+(define-accessors clusters)
+(define-accessors context)
+(define-accessors contexts)
+(define-accessors current-context)
 (define-accessors name)
 (define-accessors server)
-(define-accessors client-key)
-(define-accessors client-certificate)
-(define-accessors certificate-authority)
-
-;; lists
-(define-accessors contexts)
-(define-accessors users)
-(define-accessors clusters)
-
-;; keys that returns either references, by names, to objects, or
-;; directly an object.
-
-(define-accessors context)
 (define-accessors user)
-(define-accessors cluster)
-(define-accessors current-context)
+(define-accessors users)
 
 ;;;; UTILITY FUNCTIONS
 

--- a/cl-k8s.asd
+++ b/cl-k8s.asd
@@ -2,7 +2,6 @@
   :depends-on ("drakma"
                "cl-json"
                "cl-yaclyaml"
-               "cl-ppcre"
                "alexandria"
                "uiop")
   :description "Kubernetes client"

--- a/cl-k8s.asd
+++ b/cl-k8s.asd
@@ -1,0 +1,12 @@
+(defsystem "cl-k8s"
+  :depends-on ("drakma"
+               "cl-json"
+               "cl-yaclyaml"
+               "cl-ppcre"
+               "alexandria")
+  :description "Kubernetes client"
+  :author "brendanburns" ;; please adjust
+  :version "0.0.1" ;; please adjust
+  :license "Apache 2" ;; for example, please adjust
+  :components ((:file "packages")
+               (:file "api")))

--- a/cl-k8s.asd
+++ b/cl-k8s.asd
@@ -3,7 +3,8 @@
                "cl-json"
                "cl-yaclyaml"
                "cl-ppcre"
-               "alexandria")
+               "alexandria"
+               "uiop")
   :description "Kubernetes client"
   :author "brendanburns" ;; please adjust
   :version "0.0.1" ;; please adjust

--- a/examples.lisp
+++ b/examples.lisp
@@ -4,15 +4,13 @@
     (call-api-with-config "/api/v1/namespaces/default" (default-config)))
 
 (defun create-namespace (name)
-    (let ((ns (list 
-                '(:KIND . "Namespace")
-                '(:API-VERSION . "v1")
-                (cons :METADATA (cons (cons :NAME name) '())))))
-        (call-api-with-config
-            "/api/v1/namespaces"
-            (default-config)
-            :method :POST
-            :body ns)))
+  (call-api-with-config
+   "/api/v1/namespaces"
+   (default-config)
+   :method :POST
+   :body `((:KIND . "Namespace")
+           (:API-VERSION . "v1")
+           (:METADATA (:NAME . ,name)))))
 
 (defun delete-namespace (name)
     (call-api-with-config

--- a/examples.lisp
+++ b/examples.lisp
@@ -1,4 +1,4 @@
-(load "api.lisp")
+(in-package :cl-kubernetes-examples)
 
 (defun simple-example ()
     (call-api-with-config "/api/v1/namespaces/default" (default-config)))

--- a/examples.lisp
+++ b/examples.lisp
@@ -1,7 +1,7 @@
 (in-package :cl-kubernetes-examples)
 
 (defun simple-example ()
-    (call-api-with-config "/api/v1/namespaces/default" (default-config)))
+  (call-api-with-config "/api/v1/namespaces/default" (default-config)))
 
 (defun create-namespace (name)
   (call-api-with-config
@@ -13,28 +13,30 @@
            (:METADATA (:NAME . ,name)))))
 
 (defun delete-namespace (name)
-    (call-api-with-config
-            (concatenate 'string "/api/v1/namespaces/" name)
-            (default-config)
-            :method :DELETE))
+  (call-api-with-config
+   (concatenate 'string "/api/v1/namespaces/" name)
+   (default-config)
+   :method :DELETE))
 
 (defun create-pod ()
-    (let ((pod '((:KIND . "Pod")
-                 (:API-VERSION . "v1")
-                 (:METADATA (:NAME . "nginx"))
-                 (:SPEC
-                 (:CONTAINERS
-                    ((:NAME . "nginx") (:IMAGE . "nginx")))
-                 (:RESTART-POLICY . "Always") (:TERMINATION-GRACE-PERIOD-SECONDS . 30)
-                 (:DNS-POLICY . "ClusterFirst") (:SERVICE-ACCOUNT-NAME . "default")))))
-        (call-api-with-config
-            "/api/v1/namespaces/default/pods"
-            (default-config)
-            :method :POST
-            :body pod)))
+  (call-api-with-config
+   "/api/v1/namespaces/default/pods"
+   (default-config)
+   :method :POST
+   :body '((:KIND . "Pod")
+           (:API-VERSION . "v1")
+           (:METADATA (:NAME . "nginx"))
+           (:SPEC (:CONTAINERS
+                   ((:NAME . "nginx")
+                    (:IMAGE . "nginx")))
+            (:RESTART-POLICY . "Always")
+            (:TERMINATION-GRACE-PERIOD-SECONDS . 30)
+            (:DNS-POLICY . "ClusterFirst")
+            (:SERVICE-ACCOUNT-NAME . "default")))))
 
 (defun delete-pod (name &key (namespace "default"))
-    (call-api-with-config
-        (concatenate 'string "/api/v1/namespaces/" namespace "/pods/" name)
-        (default-config)
-        :method :DELETE))
+  (call-api-with-config
+   (concatenate 'string "/api/v1/namespaces/" namespace "/pods/" name)
+   (default-config)
+   :method :DELETE))
+

--- a/packages.lisp
+++ b/packages.lisp
@@ -3,15 +3,13 @@
 (defpackage :cl-kubernetes
   (:nicknames #:k8s)
   (:use :cl)
-  (:import-from :ppcre
-                #:split)
   (:import-from :alexandria
                 #:alist-hash-table
                 #:ensure-list
                 #:if-let)
   (:import-from :uiop
                 #:inter-directory-separator
-                #:getenvp)
+                #:getenv-pathnames)
   (:import-from :uiop/common-lisp
                 #:user-homedir-pathname)
   (:export #:call-api

--- a/packages.lisp
+++ b/packages.lisp
@@ -1,0 +1,22 @@
+(in-package :cl-user)
+
+(defpackage :cl-kubernetes
+  (:nicknames #:k8s)
+  (:use :cl)
+  (:import-from :ppcre #:split)
+  (:import-from :alexandria
+                #:alist-hash-table
+                #:ensure-list
+                #:if-let)
+  (:import-from :uiop
+                #:inter-directory-separator
+                #:getenvp)
+  (:import-from :uiop/common-lisp
+                #:user-homedir-pathname)
+  (:export #:call-api
+           #:call-api-with-config
+           #:load-config
+           #:default-config))
+
+(defpackage #:cl-kubernetes-examples
+  (:use :cl :k8s))

--- a/packages.lisp
+++ b/packages.lisp
@@ -3,7 +3,8 @@
 (defpackage :cl-kubernetes
   (:nicknames #:k8s)
   (:use :cl)
-  (:import-from :ppcre #:split)
+  (:import-from :ppcre
+                #:split)
   (:import-from :alexandria
                 #:alist-hash-table
                 #:ensure-list


### PR DESCRIPTION
Hello,

I don't really need to use Kubernetes but I found your project by chance (Twitter); here are some changes that I think could be useful. First:

- Use systems and packages (you might need to change some fields in .asd file)
- Use well-known libraries when possible: alexandria (utilities), ppcre (regex) and uiop (I/O, getenv)

The two above help with portability (some of your TODOs).

I also changed `load-config` so that it can merge configurations from multiple files (as I discovered reading k8s' doc).

There are minor indentations fixes: like most CL developers, I let the editor indent the code; the default indent, which is pretty much standard, is 2 spaces.

Finally, I tried to simplify the utility functions that come before CALL-API. This involves using a macro.

If you have any question, let me know; also, feel free to discard things from this patch.

Regards